### PR TITLE
Fix solution generation flow

### DIFF
--- a/src/agents/interview_agent.py
+++ b/src/agents/interview_agent.py
@@ -1,6 +1,10 @@
 class InterviewAgent:
     def generate_solutions_for_all_unsolved(self):
         unsolved = self.get_unsolved_questions()
+        if not unsolved:
+            # Try to populate questions if none are available yet
+            self.curate_top_company_questions()
+            unsolved = self.get_unsolved_questions()
         for question in unsolved:
             print(f"Generating solutions for: {question.get('stat', {}).get('question__title', '')}")
             py_solution = self.generate_llm_solution(question, 'python')

--- a/src/main.py
+++ b/src/main.py
@@ -7,6 +7,8 @@ def main():
     # Generate and save solutions for all unsolved top company questions
     
     agent = InterviewAgent()
+    # Ensure we have a curated list of top questions before attempting solutions
+    agent.curate_top_company_questions()
     agent.generate_solutions_for_all_unsolved()
     
     # Generate daily tasks


### PR DESCRIPTION
## Summary
- ensure unsolved questions list is generated before solving
- populate top-company questions before generating solutions

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ba28ba87483228a3dc70772709edb